### PR TITLE
Fix SPA routing page reload issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,24 @@
     gtag('js', new Date());
     gtag('config', '%VITE_GOOGLE_ANALYTICS_ID%');
   </script>
+
+  <!-- GitHub Pages SPA redirect script -->
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // https://github.com/rafgraph/spa-github-pages
+    // This script checks to see if a redirect is present in the query string,
+    // converts it back into the correct url and adds it to the browser's history
+    (function(l) {
+      if (l.search[1] === '/' ) {
+        var decoded = l.search.slice(1).split('&').map(function(s) { 
+          return s.replace(/~and~/g, '&')
+        }).join('?');
+        window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + decoded + l.hash
+        );
+      }
+    }(window.location))
+  </script>
 </head>
 <body>
   <div id="root"></div>

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,6 +1,7 @@
 // src/components/PrivateRoute.tsx
 import React from 'react';
 import { Navigate } from 'react-router-dom';
+import { CircularProgress } from '@mui/material';
 import { useUser } from '../hooks/useUser';
 
 interface PrivateRouteProps {
@@ -8,7 +9,18 @@ interface PrivateRouteProps {
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = ({ element: Component }) => {
-  const { userDetails } = useUser();
+  const { userDetails, loading } = useUser();
+  
+  // Show loading spinner while authentication state is being checked
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+        <CircularProgress />
+      </div>
+    );
+  }
+  
+  // Only redirect to home after loading is complete and no user is found
   return userDetails ? <Component /> : <Navigate to="/" />;
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,5 +22,6 @@ export default defineConfig({
         }
       }
     }
-  }
+  },
+  publicDir: 'public' // This ensures files from public/ (including 404.html) are copied to dist/
 })


### PR DESCRIPTION
- Add GitHub Pages SPA redirect script to index.html
- Update PrivateRoute to handle authentication loading state
- Configure Vite to properly copy public files including 404.html
- Fix page reloads redirecting to home instead of current route
- Ensure authentication persistence during page reloads

Fixes issue where reloading /view-material/:id or /edit-material/:id would redirect to home page instead of staying on current page. 