### PR TITLE
Fix BrowserRouter basename for GitHub Pages routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,12 +64,15 @@ const App = () => {
     },
   });
 
+  // Set basename conditionally: /nexlab/ for production, undefined for development
+  const basename = import.meta.env.PROD ? '/nexlab' : undefined;
+
   console.log("App loaded")
 
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Router>
+      <Router basename={basename}>
         {/* Conditionally render the Header based on whether the user is logged in */}
         {userDetails && <Header />}
         <div className="content">


### PR DESCRIPTION
- Add conditional basename to BrowserRouter: '/nexlab' for production, undefined for development
- Fixes URL changing from /nexlab/ to / when app loads
- Fixes 404 errors on direct links like /view-material/123 without base path
- Ensures React Router knows about GitHub Pages base path in production
- Maintains clean URLs in development (localhost:3002/view-material/123)

This resolves the issue where:
1. https://institute-for-future-intelligence.github.io/nexlab/ would change to https://institute-for-future-intelligence.github.io/
2. Direct links to /view-material/... would throw 404 errors

The basename is set conditionally using import.meta.env.PROD to match the Vite config approach.