### PR TITLE
fix: Resolve ReactQuill console errors

### DIFF
--- a/src/components/Dashboard/TextEditor.tsx
+++ b/src/components/Dashboard/TextEditor.tsx
@@ -77,7 +77,6 @@ const TextEditor: React.FC<TextEditorProps> = ({ onChange, initialValue }) => {
   // ReactQuill modules configuration
   const modules = {
     toolbar: [
-      ['undo', 'redo'],
       [{ 'header': [1, 2, 3, false] }],
       ['bold', 'italic'],
       [{ 'list': 'ordered'}, { 'list': 'bullet' }],
@@ -90,7 +89,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ onChange, initialValue }) => {
   const formats = [
     'header',
     'bold', 'italic',
-    'list', 'bullet',
+    'list',
     'blockquote', 'indent',
     'link'
   ];

--- a/src/components/Supplemental/SimpleTextEditor.tsx
+++ b/src/components/Supplemental/SimpleTextEditor.tsx
@@ -22,7 +22,7 @@ const SimpleTextEditor: React.FC<SimpleTextEditorProps> = ({ content, onChange }
   const formats = [
     'header',
     'bold', 'italic',
-    'blockquote', 'list', 'bullet',
+    'blockquote', 'list',
     'link'
   ];
 

--- a/src/components/Supplemental/TextEditor.tsx
+++ b/src/components/Supplemental/TextEditor.tsx
@@ -12,7 +12,6 @@ const TextEditor: React.FC<StandardTextEditorProps> = ({ content, onChange }) =>
   // ReactQuill modules configuration - standard toolbar
   const modules = {
     toolbar: [
-      ['undo', 'redo'],
       [{ 'header': [1, 2, 3, false] }],
       ['bold', 'italic'],
       ['blockquote', { 'list': 'ordered'}, { 'list': 'bullet' }],
@@ -24,7 +23,7 @@ const TextEditor: React.FC<StandardTextEditorProps> = ({ content, onChange }) =>
   const formats = [
     'header',
     'bold', 'italic',
-    'blockquote', 'list', 'bullet',
+    'blockquote', 'list',
     'link'
   ];
 


### PR DESCRIPTION
## 📋 Pull Request Description

**What does this PR do?**
Fixes ReactQuill console errors that appear when opening add/edit modes for materials. Cleans up ReactQuill configuration by removing unsupported toolbar items and invalid format specifications while maintaining all existing functionality.

**Related Issue(s)**
Resolves console errors: "Cannot register bullet specified in formats config" and "ignoring attaching to nonexistent format undo/redo"

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI changes
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test updates
- [ ] 🔒 Security improvement
- [ ] 🎓 Educational content update

## 📝 Changes Made

- Removed invalid 'undo' and 'redo' toolbar items (not supported by Quill)
- Fixed 'bullet' format error by removing from formats array
- Cleaned up ReactQuill configuration in all TextEditor components
- Maintains full functionality while eliminating console warnings

**Components updated:**
- Dashboard/TextEditor.tsx - Advanced editor with symbol insertion
- Supplemental/TextEditor.tsx - Standard rich text editor
- Supplemental/SimpleTextEditor.tsx - Minimal formatting editor

## 🧪 Testing

**How has this been tested?**

- [x] Type checking passes (`npm run type-check`) ← *Required check*
- [ ] Linting passes (`npm run lint`) ← *Required check*  
- [x] Build successful (`npm run build`) ← *Required check*
- [x] Manual testing completed
- [ ] Tested on different browsers/devices (if applicable)
- [ ] Firebase integration tested (if applicable)
- [x] Course management features tested (if applicable)
- [ ] Chatbot functionality tested (if applicable)

**Test scenarios covered:**
- Opening material add/edit modes (no more console errors)
- Text editor functionality (formatting, lists, links, headers)
- Custom symbol insertion in laboratory notebooks (Greek letters, math operators)
- Content saving and rendering in view modes

## 📸 Screenshots (if applicable)

**Before:**
Console showing ReactQuill errors: "Cannot register bullet specified in formats config" and "ignoring attaching to nonexistent format undo/redo"

**After:**
Clean console with no ReactQuill configuration errors when using text editors

## 🔍 Code Review Checklist

**For the Author:**
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [ ] Firebase security rules considered (if applicable)
- [ ] Environment variables properly configured (if applicable)
- [x] No sensitive information exposed in code

**For Reviewers:**
- [ ] Code follows the project's style guidelines
- [ ] Code is well-documented and easy to understand
- [ ] Changes are properly tested
- [ ] No obvious bugs or issues
- [ ] Performance impact considered (if applicable)
- [ ] Security implications reviewed (if applicable)
- [ ] Firebase/Firestore usage is efficient
- [ ] Educational content is accurate (if applicable)

## 💭 Additional Notes

**Important changes or considerations:**
This is a configuration-only fix that removes invalid ReactQuill options. No functional changes to user experience - all text editing capabilities remain intact including custom symbol insertion for educational content.

**Firebase/Database changes:**
None - this is purely a frontend configuration fix

**Related issues/PRs:**
Follow-up to the CKEditor → ReactQuill migration to resolve remaining console warnings

---

**📚 NexLAB Documentation:**
- [README](../README.md)
