### PR TITLE
Fix/message navigation

### DIFF
--- a/src/components/Messages/AddMessage.tsx
+++ b/src/components/Messages/AddMessage.tsx
@@ -37,13 +37,13 @@ const AddMessage: React.FC = () => {
         postedOn: serverTimestamp(),
         isPinned: false,
       });
-      navigate('/');
+      navigate('/messages');
     } catch (error) {
       console.error('Error adding message: ', error);
     }
   };
 
-  const handleCancel = () => navigate('/');
+  const handleCancel = () => navigate('/messages');
 
   const handleLinkChange = (index: number, field: keyof Link, value: string) => {
     const newLinks = [...links];

--- a/src/components/Messages/AddMessage.tsx
+++ b/src/components/Messages/AddMessage.tsx
@@ -8,16 +8,12 @@ import { colors, typography, spacing, borderRadius, shadows } from '../../config
 import { PageHeader } from '../common';
 
 import CourseSelector from './CourseSelector';
-
-interface Link {
-  title: string;
-  url: string;
-}
+import LinksSection, { Link } from './LinksSection';
 
 const AddMessage: React.FC = () => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [links, setLinks] = useState<Link[]>([{ title: '', url: '' }]);
+  const [links, setLinks] = useState<Link[]>([{ id: crypto.randomUUID(), title: '', url: '' }]);
 
   const [selectedCourse, setSelectedCourse] = useState<string>('');
 
@@ -53,13 +49,18 @@ const AddMessage: React.FC = () => {
     setLinks(newLinks);
   };
 
-  const addLinkField = () => setLinks([...links, { title: '', url: '' }]);
+  const addLinkField = () => setLinks([...links, { id: crypto.randomUUID(), title: '', url: '' }]);
+
+  const removeLinkField = (index: number) => {
+    const newLinks = links.filter((_, i) => i !== index);
+    setLinks(newLinks);
+  };
 
   return (
     <Container maxWidth="md" sx={{ mt: 6, fontFamily: typography.fontFamily.primary }}>
       {/* Header Section */}
       <PageHeader 
-        title="Add New Message"
+        title="Add Message"
         subtitle="Share important announcements and updates with your course participants"
       />
 
@@ -104,44 +105,13 @@ const AddMessage: React.FC = () => {
             }}
           />
 
-          <Typography variant="h6" sx={{ mb: 2 }}>
-            🔗
-          </Typography>
-          {links.map((link, index) => (
-            <Box key={index} sx={{ mb: 2, pl: 2, borderLeft: '4px solid #CDDAFF' }}>
-              <TextField
-                label={`URL Title ${index + 1}`}
-                fullWidth
-                value={link.title}
-                onChange={(e) => handleLinkChange(index, 'title', e.target.value)}
-                sx={{ mb: 1 }}
-              />
-              <TextField
-                label={`URL Link ${index + 1}`}
-                fullWidth
-                value={link.url}
-                onChange={(e) => handleLinkChange(index, 'url', e.target.value)}
-              />
-            </Box>
-          ))}
-          <Button
-            variant="outlined"
-            onClick={addLinkField}
-            startIcon={<span style={{ fontSize: '1.2rem', lineHeight: 1 }}>+</span>}
-            sx={{
-              fontFamily: 'Staatliches, sans-serif',
-              fontSize: '1rem',
-              color: '#0B53C0',
-              padding: '8px 16px',
-              textTransform: 'none',
-              '&:hover': {
-                backgroundColor: 'rgba(11, 83, 192, 0.1)',
-                color: '#083B80',
-              },
-            }}
-          >
-            Add Link
-          </Button>
+          {/* Links Section */}
+          <LinksSection 
+            links={links}
+            onLinkChange={handleLinkChange}
+            onAddLink={addLinkField}
+            onRemoveLink={removeLinkField}
+          />
 
           <Divider sx={{ width: '100%', my: 2, backgroundColor: '#DADADA' }} />
 

--- a/src/components/Messages/AddMessage.tsx
+++ b/src/components/Messages/AddMessage.tsx
@@ -4,6 +4,8 @@ import { Box, Button, TextField, Typography, Container, Divider, Paper } from '@
 import { useNavigate } from 'react-router-dom';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { getFirestore } from 'firebase/firestore';
+import { colors, typography, spacing, borderRadius, shadows } from '../../config/designSystem';
+import { PageHeader } from '../common';
 
 import CourseSelector from './CourseSelector';
 
@@ -54,22 +56,25 @@ const AddMessage: React.FC = () => {
   const addLinkField = () => setLinks([...links, { title: '', url: '' }]);
 
   return (
-    <Container maxWidth="md" sx={{ mt: 6, fontFamily: 'Gabarito, sans-serif' }}>
+    <Container maxWidth="md" sx={{ mt: 6, fontFamily: typography.fontFamily.primary }}>
+      {/* Header Section */}
+      <PageHeader 
+        title="Add New Message"
+        subtitle="Share important announcements and updates with your course participants"
+      />
+
+      {/* Form Section */}
       <Paper
         elevation={3}
         sx={{
-          p: 4,
-          borderRadius: 2,
-          backgroundColor: '#F7F9FC', // Light email-like background
+          p: spacing[6],
+          borderRadius: borderRadius['2xl'],
+          backgroundColor: colors.background.elevated,
+          border: `1px solid ${colors.neutral[200]}`,
+          boxShadow: shadows.lg,
         }}
       >
-        <Typography variant="h4" component="h1" gutterBottom sx={{ fontFamily: 'Staatliches, sans-serif', textAlign: 'center' }}>
-          Add New Message
-        </Typography>
-
-        <Divider sx={{ mb: 3, backgroundColor: '#DADADA' }} />
-
-        <Box sx={{ mt: 4 }}>
+        <Box sx={{ mt: spacing[4] }}>
           <CourseSelector value={selectedCourse} onChange={setSelectedCourse} />
 
           <TextField

--- a/src/components/Messages/CourseSelector.tsx
+++ b/src/components/Messages/CourseSelector.tsx
@@ -39,7 +39,7 @@ const CourseSelector: React.FC<CourseSelectorProps> = ({ value, onChange }) => {
         courses={adminCourses}
         label="Course"
         placeholder="Select a course"
-        helperText="Choose the course for this message"
+        helperText=""
         showNumber={true}
         showTitle={true}
         showAdminBadge={false}

--- a/src/components/Messages/EditMessage.tsx
+++ b/src/components/Messages/EditMessage.tsx
@@ -8,17 +8,13 @@ import { colors, typography, spacing, borderRadius, shadows } from '../../config
 import { PageHeader } from '../common';
 
 import CourseSelector from './CourseSelector';
-
-interface Link {
-  title: string;
-  url: string;
-}
+import LinksSection, { Link } from './LinksSection';
 
 const EditMessage: React.FC = () => {
   const { id } = useParams();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [links, setLinks] = useState<Link[]>([{ title: '', url: '' }]);
+  const [links, setLinks] = useState<Link[]>([{ id: crypto.randomUUID(), title: '', url: '' }]);
   const [selectedCourse, setSelectedCourse] = useState<string>('');
 
   const navigate = useNavigate();
@@ -34,7 +30,16 @@ const EditMessage: React.FC = () => {
           const data = docSnap.data();
           setTitle(data.title);
           setDescription(data.description);
-          setLinks(data.links || [{ title: '', url: '' }]);
+          // Convert existing links to include IDs, or create new ones if none exist
+          const existingLinks = data.links || [];
+          setLinks(existingLinks.length > 0 
+            ? existingLinks.map((link: any) => ({ 
+                id: link.id || crypto.randomUUID(), 
+                title: link.title || '', 
+                url: link.url || '' 
+              }))
+            : [{ id: crypto.randomUUID(), title: '', url: '' }]
+          );
           setSelectedCourse(data.course || '');
         }
       } catch (error) {
@@ -74,7 +79,12 @@ const EditMessage: React.FC = () => {
     setLinks(newLinks);
   };
 
-  const addLinkField = () => setLinks([...links, { title: '', url: '' }]);
+  const addLinkField = () => setLinks([...links, { id: crypto.randomUUID(), title: '', url: '' }]);
+
+  const removeLinkField = (index: number) => {
+    const newLinks = links.filter((_, i) => i !== index);
+    setLinks(newLinks);
+  };
 
   return (
     <Container maxWidth="md" sx={{ mt: 6, fontFamily: typography.fontFamily.primary }}>
@@ -124,44 +134,13 @@ const EditMessage: React.FC = () => {
               boxShadow: '0 1px 4px rgba(0, 0, 0, 0.1)',
             }}
           />
-          <Typography variant="h6" sx={{ mb: 2 }}>
-            🔗
-          </Typography>
-          {links.map((link, index) => (
-            <Box key={index} sx={{ mb: 2, pl: 2, borderLeft: '4px solid #CDDAFF' }}>
-              <TextField
-                label={`URL Title ${index + 1}`}
-                fullWidth
-                value={link.title}
-                onChange={(e) => handleLinkChange(index, 'title', e.target.value)}
-                sx={{ mb: 1 }}
-              />
-              <TextField
-                label={`URL Link ${index + 1}`}
-                fullWidth
-                value={link.url}
-                onChange={(e) => handleLinkChange(index, 'url', e.target.value)}
-              />
-            </Box>
-          ))}
-          <Button
-            variant="outlined"
-            onClick={addLinkField}
-            startIcon={<span style={{ fontSize: '1.2rem', lineHeight: 1 }}>+</span>}
-            sx={{
-              fontFamily: 'Staatliches, sans-serif',
-              fontSize: '1rem',
-              color: '#0B53C0',
-              padding: '8px 16px',
-              textTransform: 'none',
-              '&:hover': {
-                backgroundColor: 'rgba(11, 83, 192, 0.1)',
-                color: '#083B80',
-              },
-            }}
-          >
-            Add Link
-          </Button>
+          {/* Links Section */}
+          <LinksSection 
+            links={links}
+            onLinkChange={handleLinkChange}
+            onAddLink={addLinkField}
+            onRemoveLink={removeLinkField}
+          />
           
           <Divider sx={{ width: '100%', my: 2, backgroundColor: '#DADADA' }} />
 

--- a/src/components/Messages/EditMessage.tsx
+++ b/src/components/Messages/EditMessage.tsx
@@ -4,6 +4,8 @@ import { Box, Button, TextField, Typography, Container, Divider, Paper } from '@
 import { useNavigate, useParams } from 'react-router-dom';
 import { doc, getDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
 import { getFirestore } from 'firebase/firestore';
+import { colors, typography, spacing, borderRadius, shadows } from '../../config/designSystem';
+import { PageHeader } from '../common';
 
 import CourseSelector from './CourseSelector';
 
@@ -75,22 +77,25 @@ const EditMessage: React.FC = () => {
   const addLinkField = () => setLinks([...links, { title: '', url: '' }]);
 
   return (
-    <Container maxWidth="md" sx={{ mt: 6, fontFamily: 'Gabarito, sans-serif' }}>
+    <Container maxWidth="md" sx={{ mt: 6, fontFamily: typography.fontFamily.primary }}>
+      {/* Header Section */}
+      <PageHeader 
+        title="Edit Message"
+        subtitle="Update your message content and course assignment"
+      />
+
+      {/* Form Section */}
       <Paper
         elevation={3}
         sx={{
-          p: 4,
-          borderRadius: 2,
-          backgroundColor: '#F7F9FC', // Light email-like background
+          p: spacing[6],
+          borderRadius: borderRadius['2xl'],
+          backgroundColor: colors.background.elevated,
+          border: `1px solid ${colors.neutral[200]}`,
+          boxShadow: shadows.lg,
         }}
       >
-        <Typography variant="h4" component="h1" gutterBottom sx={{ fontFamily: 'Staatliches, sans-serif', textAlign: 'center' }}>
-          Edit Message
-        </Typography>
-
-        <Divider sx={{ mb: 3, backgroundColor: '#DADADA' }} />
-
-        <Box sx={{ mt: 4 }}>
+        <Box sx={{ mt: spacing[4] }}>
           <CourseSelector value={selectedCourse} onChange={setSelectedCourse} />
 
           <TextField

--- a/src/components/Messages/EditMessage.tsx
+++ b/src/components/Messages/EditMessage.tsx
@@ -58,13 +58,13 @@ const EditMessage: React.FC = () => {
         course: selectedCourse,
         lastUpdatedOn: serverTimestamp(),
       });
-      navigate('/');
+      navigate('/messages');
     } catch (error) {
       console.error('Error editing message: ', error);
     }
   };
 
-  const handleCancel = () => navigate('/');
+  const handleCancel = () => navigate('/messages');
 
   const handleLinkChange = (index: number, field: keyof Link, value: string) => {
     const newLinks = [...links];

--- a/src/components/Messages/LinksSection.tsx
+++ b/src/components/Messages/LinksSection.tsx
@@ -1,0 +1,202 @@
+// src/components/Messages/LinksSection.tsx
+import React from 'react';
+import { Box, Button, TextField, Typography, Paper, IconButton, Tooltip } from '@mui/material';
+import { DeleteOutline } from '@mui/icons-material';
+import { colors, typography, spacing, borderRadius } from '../../config/designSystem';
+
+export interface Link {
+  id: string;
+  title: string;
+  url: string;
+}
+
+interface LinksSectionProps {
+  links: Link[];
+  onLinkChange: (index: number, field: keyof Link, value: string) => void;
+  onAddLink: () => void;
+  onRemoveLink: (index: number) => void;
+}
+
+const LinksSection: React.FC<LinksSectionProps> = ({ 
+  links, 
+  onLinkChange, 
+  onAddLink,
+  onRemoveLink
+}) => {
+  return (
+    <Box sx={{ mt: spacing[5] }}>
+      <Typography 
+        variant="h6" 
+        sx={{ 
+          mb: spacing[3],
+          fontFamily: typography.fontFamily.secondary,
+          fontSize: typography.fontSize.lg,
+          fontWeight: typography.fontWeight.semibold,
+          color: colors.primary[700],
+          display: 'flex',
+          alignItems: 'center',
+          gap: spacing[2]
+        }}
+      >
+        <Box
+          sx={{
+            width: 24,
+            height: 24,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.primary[100],
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: '14px'
+          }}
+        >
+          🔗
+        </Box>
+        Links & Resources
+      </Typography>
+      
+      {links.map((link, index) => (
+        <Paper
+          key={link.id}
+          elevation={0}
+          sx={{
+            p: spacing[3],
+            mb: spacing[3],
+            backgroundColor: colors.neutral[50],
+            borderRadius: borderRadius.lg,
+            border: `1px solid ${colors.neutral[200]}`,
+            position: 'relative',
+            '&:hover': {
+              borderColor: colors.primary[300],
+              backgroundColor: colors.primary[25],
+              '& .remove-button': {
+                opacity: 1,
+                visibility: 'visible',
+              },
+            },
+            transition: 'all 0.2s ease-in-out',
+          }}
+        >
+          {/* Remove Button - appears on hover */}
+          <Tooltip title="Remove this link" arrow placement="top">
+            <IconButton
+              className="remove-button"
+              onClick={() => onRemoveLink(index)}
+              sx={{
+                position: 'absolute',
+                top: spacing[2],
+                right: spacing[2],
+                width: 32,
+                height: 32,
+                backgroundColor: colors.error[50],
+                border: `1px solid ${colors.error[200]}`,
+                borderRadius: borderRadius.sm,
+                opacity: 0,
+                visibility: 'hidden',
+                transition: 'all 0.2s ease-in-out',
+                '&:hover': {
+                  backgroundColor: colors.error[100],
+                  borderColor: colors.error[300],
+                  transform: 'scale(1.05)',
+                },
+                '& .MuiSvgIcon-root': {
+                  fontSize: '16px',
+                  color: colors.error[600],
+                },
+              }}
+            >
+              <DeleteOutline />
+            </IconButton>
+          </Tooltip>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: spacing[2] }}>
+            <Typography
+              variant="body2"
+              sx={{
+                fontFamily: typography.fontFamily.secondary,
+                fontSize: typography.fontSize.sm,
+                fontWeight: typography.fontWeight.medium,
+                color: colors.text.secondary,
+              }}
+            >
+              Link {index + 1}
+            </Typography>
+          </Box>
+          
+          <Box sx={{ display: 'flex', gap: spacing[3], alignItems: 'flex-start' }}>
+            <TextField
+              label="Link Title"
+              fullWidth
+              value={link.title}
+              onChange={(e) => onLinkChange(index, 'title', e.target.value)}
+              placeholder="Enter a descriptive title for this link"
+              sx={{ 
+                flex: '0 0 65%',
+                '& .MuiOutlinedInput-root': {
+                  borderRadius: borderRadius.lg,
+                  backgroundColor: colors.surface.primary,
+                },
+              }}
+            />
+            <TextField
+              label="URL"
+              fullWidth
+              value={link.url}
+              onChange={(e) => onLinkChange(index, 'url', e.target.value)}
+              placeholder="https://example.com"
+              sx={{ 
+                flex: '0 0 35%',
+                '& .MuiOutlinedInput-root': {
+                  borderRadius: borderRadius.lg,
+                  backgroundColor: colors.surface.primary,
+                },
+              }}
+            />
+          </Box>
+        </Paper>
+      ))}
+      
+      <Button
+        variant="outlined"
+        onClick={onAddLink}
+        startIcon={
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              borderRadius: borderRadius.sm,
+              backgroundColor: colors.primary[100],
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '14px',
+              fontWeight: typography.fontWeight.semibold,
+              color: colors.primary[700],
+            }}
+          >
+            +
+          </Box>
+        }
+        sx={{
+          fontFamily: typography.fontFamily.secondary,
+          fontSize: typography.fontSize.base,
+          fontWeight: typography.fontWeight.medium,
+          color: colors.primary[600],
+          borderColor: colors.primary[300],
+          borderRadius: borderRadius.lg,
+          padding: `${spacing[2]} ${spacing[4]}`,
+          textTransform: 'none',
+          '&:hover': {
+            backgroundColor: colors.primary[50],
+            borderColor: colors.primary[400],
+            color: colors.primary[700],
+          },
+          transition: 'all 0.2s ease-in-out',
+        }}
+      >
+        Add Link
+      </Button>
+    </Box>
+  );
+};
+
+export default LinksSection;


### PR DESCRIPTION
1. fix: update message navigation to return to messages page
- Fix Add Message navigation to go to /messages instead of home
- Fix Edit Message navigation to go to /messages instead of home
- Fix Cancel actions to go to /messages instead of home

2. feat: use PageHeader component for consistent styling
- Replace manual header implementation with PageHeader component
- Fix background color to match design system (colors.primary[100])
- Ensure consistent styling across Add/Edit Message pages
- Remove helper text from Messages CourseSelector

3. feat: modernize links section with reusable component and fix deletion bug
- Create reusable LinksSection component for better modularity
- Modernize links UI with sleek hover-based remove buttons
- Place title and URL fields on same line (65%/35% split)
- Change button text from 'Add Another Link' to 'Add Link'
- Remove visual counters for cleaner design
- Fix link deletion bug by using stable UUID keys instead of array indices
- Add backward compatibility for existing messages without link IDs
- Change header text from 'Add New Message' to 'Add Message'
- Ensure consistent UX across Add/Edit Message pages