### PR TITLE
feat: create reusable MaterialSelector with green color differentiation

### DIFF
--- a/src/components/Chatbot/ChatbotRequestPage.tsx
+++ b/src/components/Chatbot/ChatbotRequestPage.tsx
@@ -1,10 +1,8 @@
 // src/components/Chatbot/ChatbotRequestPage.tsx
 import React, { useEffect, useState } from 'react';
 import {
-  MenuItem,
   Snackbar,
   Alert,
-  CircularProgress,
   Grid,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
@@ -16,11 +14,12 @@ import {
   FormContainer, 
   FormSection, 
   FormField, 
-  FormSelect, 
   FormActions, 
   FormActionButton,
   CourseSelector,
-  CourseOption
+  CourseOption,
+  MaterialSelector,
+  Material
 } from '../common';
 
 import { useMaterialsStore } from '../../stores/materialsStore';
@@ -169,7 +168,7 @@ const ChatbotRequestPage: React.FC = () => {
 
         {/* Two-column layout for Course and Material selectors */}
         <Grid container spacing={3}>
-          <Grid item xs={12} md={3}>
+          <Grid item xs={12} md={6}>
             <CourseSelector
               value={courseId}
               onChange={setCourseId}
@@ -184,36 +183,27 @@ const ChatbotRequestPage: React.FC = () => {
             />
           </Grid>
 
-          <Grid item xs={12} md={9}>
-            <FormSelect
-              label="Material"
+          <Grid item xs={12} md={6}>
+            <MaterialSelector
               value={materialId}
-              onChange={(e) => setMaterialId(e.target.value as string)}
-              required
-              disabled={!courseId || materialsLoading}
+              onChange={setMaterialId}
+              materials={materials.map(material => ({
+                id: material.id,
+                title: material.title,
+                course: material.course
+              }))}
+              label="Material"
+              placeholder="Select a material"
               helperText={
                 !courseId
                   ? 'Please select a course first.'
                   : materialsError || (materialsLoading ? 'Loading materials...' : materials.length === 0 ? 'No materials available for this course.' : 'Select the primary material for your chatbot')
               }
-            >
-              {!courseId ? (
-                <MenuItem disabled>Please select a course first</MenuItem>
-              ) : materialsLoading ? (
-                <MenuItem disabled>
-                  <CircularProgress size={20} sx={{ marginRight: 2 }} />
-                  Loading...
-                </MenuItem>
-              ) : materials.length === 0 ? (
-                <MenuItem disabled>No materials found</MenuItem>
-              ) : (
-                materials.map((material) => (
-                  <MenuItem key={material.id} value={material.id}>
-                    {material.title}
-                  </MenuItem>
-                ))
-              )}
-            </FormSelect>
+              required
+              disabled={!courseId || materialsLoading}
+              loading={materialsLoading}
+              error={!!materialsError}
+            />
           </Grid>
         </Grid>
       </FormSection>

--- a/src/components/common/MaterialSelector.tsx
+++ b/src/components/common/MaterialSelector.tsx
@@ -1,0 +1,282 @@
+// src/components/common/MaterialSelector.tsx
+import React from 'react';
+import {
+  FormControl,
+  Select,
+  MenuItem,
+  Typography,
+  Box,
+  CircularProgress,
+  FormLabel,
+  FormHelperText,
+} from '@mui/material';
+import { colors, typography, spacing, borderRadius } from '../../config/designSystem';
+
+export interface Material {
+  id: string;
+  title: string;
+  course?: string;
+}
+
+interface MaterialSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+  materials: Material[];
+  label?: string;
+  placeholder?: string;
+  helperText?: string;
+  error?: boolean;
+  disabled?: boolean;
+  loading?: boolean;
+  required?: boolean;
+  fullWidth?: boolean;
+  variant?: 'outlined' | 'filled' | 'standard';
+  size?: 'small' | 'medium';
+  sx?: any;
+}
+
+const MaterialSelector: React.FC<MaterialSelectorProps> = ({
+  value,
+  onChange,
+  materials,
+  label = 'Material',
+  placeholder,
+  helperText,
+  error = false,
+  disabled = false,
+  loading = false,
+  required = false,
+  fullWidth = true,
+  variant = 'outlined',
+  size = 'medium',
+  sx,
+}) => {
+  const getSelectedMaterial = () => {
+    return materials.find(material => material.id === value);
+  };
+
+  const selectedMaterial = getSelectedMaterial();
+
+  return (
+    <FormControl 
+      fullWidth={fullWidth}
+      error={error}
+      disabled={disabled}
+      required={required}
+      variant={variant}
+      size={size}
+      sx={{
+        '& .MuiOutlinedInput-root': {
+          borderRadius: borderRadius.lg,
+          backgroundColor: colors.surface.primary,
+          border: `2px solid ${colors.neutral[300]}`,
+          minHeight: size === 'small' ? '48px' : '56px',
+          
+          '&:hover': {
+            backgroundColor: colors.surface.primary,
+            borderColor: colors.neutral[300],
+          },
+          
+          '&.Mui-focused': {
+            backgroundColor: colors.surface.primary,
+            borderColor: colors.primary[500],
+            borderWidth: '2px',
+          },
+          
+          '&.Mui-error': {
+            borderColor: colors.error,
+          },
+          
+          '& .MuiSelect-select': {
+            padding: size === 'small' ? '12px 14px' : '16px 14px',
+            boxSizing: 'border-box',
+            fontFamily: typography.fontFamily.primary,
+            fontSize: typography.fontSize.base,
+            color: colors.text.primary,
+          },
+        },
+        
+        '& .MuiOutlinedInput-notchedOutline': {
+          border: 'none', // Remove the default outline
+        },
+        
+        '& .MuiInputLabel-root': {
+          fontFamily: typography.fontFamily.secondary,
+          fontSize: typography.fontSize.base,
+          fontWeight: typography.fontWeight.medium,
+          color: colors.text.secondary,
+          transform: 'none',
+          position: 'static',
+          marginBottom: spacing[1],
+          
+          '&.Mui-focused': {
+            color: colors.primary[600],
+          },
+          
+          '&.Mui-error': {
+            color: colors.error,
+          },
+        },
+        
+        '& .MuiFormHelperText-root': {
+          fontFamily: typography.fontFamily.primary,
+          fontSize: typography.fontSize.sm,
+          marginTop: spacing[1],
+          minHeight: '20px',
+          lineHeight: '1.2',
+        },
+        
+        ...sx,
+      }}
+    >
+      <FormLabel 
+        required={required}
+        sx={{
+          mb: 1,
+          fontFamily: typography.fontFamily.secondary,
+          fontSize: typography.fontSize.base,
+          fontWeight: typography.fontWeight.medium,
+          color: colors.text.secondary,
+        }}
+      >
+        {label}
+      </FormLabel>
+      
+      <Select
+        value={value}
+        onChange={(e) => onChange(e.target.value as string)}
+        displayEmpty
+        renderValue={(selected) => {
+          if (!selected) {
+            return (
+              <Typography
+                sx={{
+                  color: colors.text.secondary,
+                  fontFamily: typography.fontFamily.primary,
+                  fontSize: typography.fontSize.base,
+                }}
+              >
+                {placeholder || `Select ${label.toLowerCase()}`}
+              </Typography>
+            );
+          }
+
+          const material = getSelectedMaterial();
+          if (!material) return '';
+
+          return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: spacing[2] }}>
+              {/* Material Title in styled box */}
+              <Box
+                sx={{
+                  backgroundColor: '#D1FAE5', // colors.success.light
+                  border: `1px solid #22C55E`, // colors.success.main
+                  borderRadius: borderRadius.lg,
+                  padding: `${spacing[2]} ${spacing[3]}`,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: spacing[1],
+                  width: 'fit-content',
+                  maxWidth: '100%',
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontFamily: typography.fontFamily.secondary,
+                    fontSize: typography.fontSize.sm,
+                    fontWeight: typography.fontWeight.semibold,
+                    color: '#059669', // colors.success.dark
+                    flexShrink: 0,
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {material.title}
+                </Typography>
+              </Box>
+            </Box>
+          );
+        }}
+      >
+        {loading ? (
+          <MenuItem disabled>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: spacing[2] }}>
+              <CircularProgress size={20} />
+              <Typography sx={{ fontFamily: typography.fontFamily.primary }}>
+                Loading materials...
+              </Typography>
+            </Box>
+          </MenuItem>
+        ) : materials.length > 0 ? (
+          materials.map((material) => (
+            <MenuItem
+              key={material.id}
+              value={material.id}
+              sx={{
+                padding: spacing[2],
+                '&:hover': {
+                  backgroundColor: '#ECFDF5', // Very light green hover
+                },
+                '&.Mui-selected': {
+                  backgroundColor: '#D1FAE5', // colors.success.light
+                  '&:hover': {
+                    backgroundColor: '#A7F3D0', // Slightly darker green
+                  },
+                },
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: spacing[2], width: '100%' }}>
+                {/* Material Title in styled box */}
+                <Box
+                  sx={{
+                    backgroundColor: '#A7F3D0', // Medium green for dropdown items
+                    border: `1px solid #22C55E`, // colors.success.main
+                    borderRadius: borderRadius.lg,
+                    padding: `${spacing[2]} ${spacing[3]}`,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: spacing[1],
+                    width: 'fit-content',
+                    maxWidth: '100%',
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      fontFamily: typography.fontFamily.secondary,
+                      fontSize: typography.fontSize.sm,
+                      fontWeight: typography.fontWeight.semibold,
+                      color: '#059669', // colors.success.dark
+                      flexShrink: 0,
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {material.title}
+                  </Typography>
+                </Box>
+              </Box>
+            </MenuItem>
+          ))
+        ) : (
+          <MenuItem disabled>
+            <Typography sx={{ fontFamily: typography.fontFamily.primary, color: colors.text.secondary }}>
+              No materials available
+            </Typography>
+          </MenuItem>
+        )}
+      </Select>
+      
+      {helperText && (
+        <FormHelperText>
+          {helperText}
+        </FormHelperText>
+      )}
+    </FormControl>
+  );
+};
+
+export default MaterialSelector;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -12,6 +12,8 @@ export { default as CopyableUserID } from './CopyableUserID';
 export { default as CourseHyperlink } from './CourseHyperlink';
 export { default as CourseSelector } from './CourseSelector';
 export type { CourseOption } from './CourseSelector';
+export { default as MaterialSelector } from './MaterialSelector';
+export type { Material } from './MaterialSelector';
 export { default as MaterialHyperlink } from './MaterialHyperlink';
 export { default as UserStatusChip } from './UserStatusChip';
 export { default as CopyableChatbotID } from './CopyableChatbotID';


### PR DESCRIPTION
feat: create reusable MaterialSelector with green color differentiation

- Create new MaterialSelector component for consistent material dropdowns
- Apply green color scheme to differentiate from blue course selectors
- Update ChatbotRequestPage to use MaterialSelector with 50/50 layout
- Change proportions from 25%/75% to 50%/50% for course and material selectors
- Ensure material titles use consistent styling with app design system
- Add proper hover states and loading indicators
- Export MaterialSelector from common components index
- Remove unused imports (MenuItem, CircularProgress, FormSelect)
- Maintain full TypeScript support and error handling