### PR TITLE
Fix Lab Notebook panel layout consistency

### DIFF
--- a/src/components/LaboratoryNotebookV2/Panels/EditPanel.tsx
+++ b/src/components/LaboratoryNotebookV2/Panels/EditPanel.tsx
@@ -241,46 +241,7 @@ const EditPanel: React.FC = () => {
           />
         </Box>
 
-        {/* Divider */}
-        <Divider sx={{ my: spacing[2] }} />
-
-        {/* Image Upload Section */}
-        <ImageUploadSection
-          images={images}
-          onImagesChange={setImages}
-          storagePath={
-            isDesignNode(node)
-              ? `designs/${node.data.designId}`
-              : isBuildNode(node)
-              ? `builds/${node.data.buildId}`
-              : isTestNode(node)
-              ? `tests/${node.data.testId}`
-              : ''
-          }
-          disabled={isSubmitting}
-        />
-
-        {/* Divider */}
-        <Divider sx={{ my: spacing[2] }} />
-
-        {/* File Upload Section */}
-        <FileUploadSection
-          files={files}
-          onFilesChange={setFiles}
-          storagePath={
-            isDesignNode(node)
-              ? `designs/${node.data.designId}`
-              : isBuildNode(node)
-              ? `builds/${node.data.buildId}`
-              : isTestNode(node)
-              ? `tests/${node.data.testId}`
-              : ''
-          }
-          disabled={isSubmitting}
-          maxFileSize={10}
-        />
-
-        {/* Test-specific fields */}
+        {/* Test-specific fields - Results and Conclusions come before Images/Files */}
         {isTestNode(node) && (
           <>
             <Box>
@@ -324,6 +285,45 @@ const EditPanel: React.FC = () => {
             </Box>
           </>
         )}
+
+        {/* Divider */}
+        <Divider sx={{ my: spacing[2] }} />
+
+        {/* Image Upload Section */}
+        <ImageUploadSection
+          images={images}
+          onImagesChange={setImages}
+          storagePath={
+            isDesignNode(node)
+              ? `designs/${node.data.designId}`
+              : isBuildNode(node)
+              ? `builds/${node.data.buildId}`
+              : isTestNode(node)
+              ? `tests/${node.data.testId}`
+              : ''
+          }
+          disabled={isSubmitting}
+        />
+
+        {/* Divider */}
+        <Divider sx={{ my: spacing[2] }} />
+
+        {/* File Upload Section */}
+        <FileUploadSection
+          files={files}
+          onFilesChange={setFiles}
+          storagePath={
+            isDesignNode(node)
+              ? `designs/${node.data.designId}`
+              : isBuildNode(node)
+              ? `builds/${node.data.buildId}`
+              : isTestNode(node)
+              ? `tests/${node.data.testId}`
+              : ''
+          }
+          disabled={isSubmitting}
+          maxFileSize={10}
+        />
       </Box>
 
       {/* Actions */}

--- a/src/components/LaboratoryNotebookV2/Panels/ExpandedAddTestPanel.tsx
+++ b/src/components/LaboratoryNotebookV2/Panels/ExpandedAddTestPanel.tsx
@@ -18,7 +18,10 @@ import { Close as CloseIcon, Add as AddIcon, ArrowBack as ArrowBackIcon } from '
 import { colors, typography, spacing, borderRadius } from '../../../config/designSystem';
 import { useLabNotebookStore } from '../../../stores/labNotebookStore';
 import { labNotebookService } from '../../../services/labNotebookService';
+import { Image, FileDetails } from '../../../types/types';
 import RichTextEditor from '../RichTextEditor';
+import ImageUploadSection from '../ImageUploadSection';
+import FileUploadSection from '../FileUploadSection';
 
 interface ExpandedAddTestPanelProps {
   designId?: string;
@@ -68,6 +71,8 @@ const ExpandedAddTestPanel: React.FC<ExpandedAddTestPanelProps> = ({ designId: p
   const [description, setDescription] = useState('');
   const [results, setResults] = useState('');
   const [conclusions, setConclusions] = useState('');
+  const [images, setImages] = useState<Image[]>([]);
+  const [files, setFiles] = useState<FileDetails[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -121,6 +126,8 @@ const ExpandedAddTestPanel: React.FC<ExpandedAddTestPanelProps> = ({ designId: p
         description: description.trim(),
         results: results.trim(),
         conclusions: conclusions.trim(),
+        images: images,
+        files: files,
       });
 
       // Refresh data
@@ -314,6 +321,33 @@ const ExpandedAddTestPanel: React.FC<ExpandedAddTestPanelProps> = ({ designId: p
                 disabled={isSubmitting}
               />
             </Box>
+
+            {/* Divider */}
+            <Box sx={{ my: spacing[3] }}>
+              <hr style={{ border: 'none', borderTop: `1px solid ${colors.neutral[200]}`, margin: 0 }} />
+            </Box>
+
+            {/* Image Upload Section */}
+            <ImageUploadSection
+              images={images}
+              onImagesChange={setImages}
+              storagePath="" // Will be set after creation
+              disabled={isSubmitting}
+            />
+
+            {/* Divider */}
+            <Box sx={{ my: spacing[3] }}>
+              <hr style={{ border: 'none', borderTop: `1px solid ${colors.neutral[200]}`, margin: 0 }} />
+            </Box>
+
+            {/* File Upload Section */}
+            <FileUploadSection
+              files={files}
+              onFilesChange={setFiles}
+              storagePath="" // Will be set after creation
+              disabled={isSubmitting}
+              maxFileSize={10}
+            />
           </Box>
         )}
       </Box>

--- a/src/components/LaboratoryNotebookV2/Panels/ExpandedEditPanel.tsx
+++ b/src/components/LaboratoryNotebookV2/Panels/ExpandedEditPanel.tsx
@@ -239,46 +239,7 @@ const ExpandedEditPanel: React.FC = () => {
             />
           </Box>
 
-          {/* Divider */}
-          <Divider sx={{ my: spacing[3] }} />
-
-          {/* Image Upload Section */}
-          <ImageUploadSection
-            images={images}
-            onImagesChange={setImages}
-            storagePath={
-              isDesignNode(node)
-                ? `designs/${node.data.designId}`
-                : isBuildNode(node)
-                ? `builds/${node.data.buildId}`
-                : isTestNode(node)
-                ? `tests/${node.data.testId}`
-                : ''
-            }
-            disabled={isSubmitting}
-          />
-
-          {/* Divider */}
-          <Divider sx={{ my: spacing[3] }} />
-
-          {/* File Upload Section */}
-          <FileUploadSection
-            files={files}
-            onFilesChange={setFiles}
-            storagePath={
-              isDesignNode(node)
-                ? `designs/${node.data.designId}`
-                : isBuildNode(node)
-                ? `builds/${node.data.buildId}`
-                : isTestNode(node)
-                ? `tests/${node.data.testId}`
-                : ''
-            }
-            disabled={isSubmitting}
-            maxFileSize={10}
-          />
-
-          {/* Test-specific fields */}
+          {/* Test-specific fields - Results and Conclusions come before Images/Files */}
           {isTestNode(node) && (
             <>
               <Box>
@@ -324,6 +285,45 @@ const ExpandedEditPanel: React.FC = () => {
               </Box>
             </>
           )}
+
+          {/* Divider */}
+          <Divider sx={{ my: spacing[3] }} />
+
+          {/* Image Upload Section */}
+          <ImageUploadSection
+            images={images}
+            onImagesChange={setImages}
+            storagePath={
+              isDesignNode(node)
+                ? `designs/${node.data.designId}`
+                : isBuildNode(node)
+                ? `builds/${node.data.buildId}`
+                : isTestNode(node)
+                ? `tests/${node.data.testId}`
+                : ''
+            }
+            disabled={isSubmitting}
+          />
+
+          {/* Divider */}
+          <Divider sx={{ my: spacing[3] }} />
+
+          {/* File Upload Section */}
+          <FileUploadSection
+            files={files}
+            onFilesChange={setFiles}
+            storagePath={
+              isDesignNode(node)
+                ? `designs/${node.data.designId}`
+                : isBuildNode(node)
+                ? `builds/${node.data.buildId}`
+                : isTestNode(node)
+                ? `tests/${node.data.testId}`
+                : ''
+            }
+            disabled={isSubmitting}
+            maxFileSize={10}
+          />
         </Box>
       </Box>
 


### PR DESCRIPTION
- Fix EditPanel: Move Images and Files sections after Results and Conclusions for test nodes
- Fix ExpandedEditPanel: Ensure same order as AddTest mode (Description → Results → Conclusions → Images → Files)
- Fix ExpandedAddTestPanel: Add missing Images and Files sections