### PR TITLE
fix: remove height limitation from Chatbot Management table

### DIFF
--- a/src/components/Chatbot/ModernChatbotRequestsTable.tsx
+++ b/src/components/Chatbot/ModernChatbotRequestsTable.tsx
@@ -125,7 +125,6 @@ const ModernChatbotRequestsTable: React.FC<ModernChatbotRequestsTableProps> = ({
       columns={columns}
       loading={loading}
       emptyMessage="No chatbot requests found. Submit your first request to get started!"
-      maxHeight="600px"
       stickyHeader={true}
     />
   );


### PR DESCRIPTION
- Remove maxHeight='600px' from ModernChatbotRequestsTable
- Allows all chatbot request records to be visible without truncation